### PR TITLE
Update MaxKernel for Sequoia (Patch 2 Only)

### DIFF
--- a/CaseySJ-Aquantia-Patch-Sets-1-and-2.plist
+++ b/CaseySJ-Aquantia-Patch-Sets-1-and-2.plist
@@ -296,7 +296,7 @@
 				<key>Mask</key>
 				<data>+P/H////////</data>
 				<key>MaxKernel</key>
-				<string>23.99.99</string>
+				<string>24.99.99</string>
 				<key>MinKernel</key>
 				<string>21.0.0</string>
 				<key>Replace</key>
@@ -326,7 +326,7 @@
 				<key>Mask</key>
 				<data>//8A////8P///w==</data>
 				<key>MaxKernel</key>
-				<string>23.99.99</string>
+				<string>24.99.99</string>
 				<key>MinKernel</key>
 				<string>21.0.0</string>
 				<key>Replace</key>


### PR DESCRIPTION
Thank you for the amazing patches. Currently Patch Set 2 works with macOS 15 Sequoia, so the only thing I changed is MaxKernel. I did not test Patch Set 1 so this is more like a FYI for those already upgraded to Sequoia.